### PR TITLE
#13 Add optional principal user to mail methods to allow actions to b…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.0.14
+
+* mail functions can now take an optional username or user id to perform the action on behalf of.
+* fixed bug in create request model which inadvertently included an invalid value to the JSON data.
+
 ## 0.0.13
 
 * decoupled library from Flutter allowing its use in pure Dart applications

--- a/README.md
+++ b/README.md
@@ -510,12 +510,22 @@ List<ContactFolder> contactFolders = await Contacts.listContactFolders();
 <details>
   <summary>Mail</summary>
 
+#### Overview
+
+By default, the mail methods run against the user authorised by the token. Each of the
+mail methods can take an optional username/id to specify which user to run the actions as. 
+
 #### Get Mail Folders
 
 The `getMailFolders` method fetches all mail folders from the Microsoft Graph API. It returns a list of `MailFolder` objects.
 
 ```dart
 List<MailFolder> folders = await graphAPI.mail.getMailFolders();
+```
+or to fetch the folders for a specific user:
+
+```dart
+List<MailFolder> folders = await graphAPI.mail.getMailFolders(userIdOrPrincipal: 'someuser@outlook.com');
 ```
 
 #### Get Messages
@@ -525,6 +535,9 @@ The `getMessages` method retrieves emails from a specified folder or from the in
 ```dart
 // Get messages from inbox
 List<Message> messages = await graphAPI.mail.getMessages();
+
+// Get messages from inbox for a specific user (with appropriate permissions)
+List<Message> messages = await graphAPI.mail.getMessages(userIdOrPrincipal: 'someuser@outlook.com');
 
 // Get messages from a specific folder
 List<Message> messages = await graphAPI.mail.getMessages(folderId: 'folderIdHere');

--- a/lib/models/mail/message_create_request_model.dart
+++ b/lib/models/mail/message_create_request_model.dart
@@ -25,7 +25,9 @@ class MessageCreateRequest {
   /// The BCC recipient list for the message.
   final List<Recipient>? bccRecipients;
 
-  /// Whether to save the message in the Sent Items folder.
+  /// Whether to save the message in the Sent Items folder. Exclude from JSON
+  /// generation as we use this field directly.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   final bool? saveToSentItems;
 
   MessageCreateRequest({

--- a/lib/models/mail/message_create_request_model.g.dart
+++ b/lib/models/mail/message_create_request_model.g.dart
@@ -21,7 +21,6 @@ MessageCreateRequest _$MessageCreateRequestFromJson(
       bccRecipients: (json['bccRecipients'] as List<dynamic>?)
           ?.map((e) => Recipient.fromJson(e as Map<String, dynamic>))
           .toList(),
-      saveToSentItems: json['saveToSentItems'] as bool?,
     );
 
 Map<String, dynamic> _$MessageCreateRequestToJson(
@@ -33,5 +32,4 @@ Map<String, dynamic> _$MessageCreateRequestToJson(
       'toRecipients': instance.toRecipients,
       'ccRecipients': instance.ccRecipients,
       'bccRecipients': instance.bccRecipients,
-      'saveToSentItems': instance.saveToSentItems,
     };

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: microsoft_graph_api
 description: Dart package for seamless Microsoft 365 data access via Microsoft Graph API.
-version: 0.0.13
+version: 0.0.14
 repository: https://github.com/PlaxXOnline/microsoft_graph_api
 issue_tracker: https://github.com/PlaxXOnline/microsoft_graph_api/issues
 


### PR DESCRIPTION
Hi @PlaxXOnline,

This PR is an implementation of my thoughts about #13.

The thinking here is that every mail method can take an optional `principalUserNameOfId` value. When specified, it will call the correct version of the endpoint to run it as the specified user. If the user is not specified, it will run as is under the `/me` endpoint, so any existing code will run without breaking.

I also had a problem with creating a draft which turned out to be the `saveToSentItems` flag being included in the JSON payload of the message which resulted in a deserialisation error from the API. 

I have updated `CHANGELOG.md`, `README.md` and updated the version number in `pubspec.yaml`.

I hope this PR meets with your approval and I welcome any feedback.

Thanks again for this really useful library.